### PR TITLE
feat(readme): add extensive Comfy templates table at topUpdate README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,101 +1,109 @@
 # Templates for the [ComfyUI Interface](https://github.com/comfyanonymous/ComfyUI)
 
-## Workflows for the ComfyUI at [Wyrde ComfyUI Workflows](https://github.com/wyrde/wyrde-comfyui-workflows)
+## 내 Comfy 템플릿 정리
+https://github.com/atlasunified/Templates-ComfyUI-
 
-ADDED: Co-LoRA NET -- A mixture of control net and LoRA that allows for robust sketches and what not...
-
-## Co-LoRA NET
-
-Not sure if this is just control net or if LoRA is doing anything to help it...
-
-Co-LoRA NET
-![alt text](https://github.com/atlasunified/Templates-ComfyUI-/blob/main/co-loranet/images/co-loranet.PNG)
-![alt text](https://github.com/atlasunified/Templates-ComfyUI-/blob/main/co-loranet/images/co-loranet-invert.PNG)
------
-
-## 512 x 512
-
-See the differentiation between samplers in this 14 image simple prompt generator.
-
--- Showcase random and singular seeds
-
--- Dashboard random and singular seeds to manipulate individual image settings
-
--- ** UPDATED: Random and Uniform Dashboards to reflect DPM Adaptive working but sus, and made things cleaner.
-
-Sampler Showcase
-![alt text](https://github.com/atlasunified/Templates-ComfyUI-/blob/main/512x512/images/5125122.PNG)
-![alt text](https://github.com/atlasunified/Templates-ComfyUI-/blob/main/512x512/images/5125121.PNG)
------
-
-Manipulate settings for each sampler to elicit better generations.
-
-Random Dashboard
-![alt text](https://github.com/atlasunified/Templates-ComfyUI-/blob/main/512x512/images/512x512-random-dash.PNG)
-Uniform Dashboard
-![alt text](https://github.com/atlasunified/Templates-ComfyUI-/blob/main/512x512/images/512x512-uniform-dash.PNG)
------
-## 512 x 640 - Portrait Mode
-
-See the differentiation between samplers in this 14 image simple prompt generator.
-
-Only random atm.
-
--- Showcase random seeds
--- Dashboard random seeds to manipulate individual image settings
-
-Portrait Sampler Showcase
-![alt text](https://github.com/atlasunified/Templates-ComfyUI-/blob/main/512X640/images/512640.PNG)
-![alt text](https://github.com/atlasunified/Templates-ComfyUI-/blob/main/512X640/images/5126402.PNG)
------
-Portrait Sampler Dashboard
-![alt text](https://github.com/atlasunified/Templates-ComfyUI-/blob/main/512X640/images/51640dash.PNG)
------
-## 768 x 512 - Landscape Mode
-
-This is my favorite.
-
------
-Landscape Sampler Showcase
-![alt text](https://github.com/atlasunified/Templates-ComfyUI-/blob/main/768x512/images/uniform%20showcase.PNG)
-![alt text](https://github.com/atlasunified/Templates-ComfyUI-/blob/main/768x512/images/random%20showcase.PNG)
------
-Landscape Sampler Dashboard
-![alt text](https://github.com/atlasunified/Templates-ComfyUI-/blob/main/768x512/images/uniform%20dash.PNG)
-![alt text](https://github.com/atlasunified/Templates-ComfyUI-/blob/main/768x512/images/random%20dash.PNG)
------
-## High-Resolution Fix
-
-Upscale your generations.
-
-HighRes Fix
-![alt text](https://github.com/atlasunified/Templates-ComfyUI-/blob/main/Hi-Res%20Fix/images/high-res.PNG)
------
-## Control Net
-
-I must admit, this is a pretty good one, the example was spot on!
-
-Control Net
-![alt text](https://github.com/atlasunified/Templates-ComfyUI-/blob/main/Control%20Net/images/controlnet.PNG)
------
-## Area Composition
-
-This one is difficult to master as I don't have the models used in the example.
-
-AreaComp
-![alt text](https://github.com/atlasunified/Templates-ComfyUI-/blob/main/Area%20Composition/images/AreaComp.PNG)
------
-# Image Upscaler
-
-Put your favorite upscaler in this compact tool.
-
-Image Upscaler
-![alt text](https://github.com/atlasunified/Templates-ComfyUI-/blob/main/image-upscaler/images/image-upscaler.PNG)
------
-# LoRA Loader and Modeling
-
-While I'm not a fan of anime, save Akira, this LoRA modeler may be great for anime scenes, see the repo ID'd in template.
-
-LoRA Loader and Modeling
-![alt text](https://github.com/atlasunified/Templates-ComfyUI-/blob/main/lora-loader/images/lora-loader.PNG)
------
+| 종류 | 설명 | 파일 및 경로 |
+|------|------|-------------|
+| Wan 2.2 Text to Video | 텍스트→영상 | [templates/video_wan2_2_t2v.json](https://github.com/Comfy-Org/workflow_templates/tree/main/templates) |
+| Wan 2.2 Text to Video 2 | 텍스트→영상, 14B | [templates/video_wan2_2_14B_t2v.json](https://github.com/Comfy-Org/workflow_templates/tree/main/templates) |
+| Wan 2.2 Image to Video | 이미지→영상 | [templates/video_wan2_2_i2v.json](https://github.com/Comfy-Org/workflow_templates/tree/main/templates) |
+| Wan 2.2 Image to Video 2 | 이미지→영상, 14B | [templates/video_wan2_2_14B_i2v.json](https://github.com/Comfy-Org/workflow_templates/tree/main/templates) |
+| Flux Kontext Dev Image Edit | 부분 편집/일관성 | [index.json:flux_kontext_dev_basic](https://github.com/Comfy-Org/workflow_templates/blob/main/templates/index.json) |
+| Flux Kontext SD3 Edit | SD3 캐릭터 편집 | [index.json:flux_kontext_sd3_edit](https://github.com/Comfy-Org/workflow_templates/blob/main/templates/index.json) |
+| Qwen-Image Union Control | ControlNet 통합 | [index.json:image_qwen_image_union_control_lora](https://github.com/Comfy-Org/workflow_templates/blob/main/templates/index.json) |
+| Qwen-Image Img2Img | 이미지 편집 | [index.json:image_qwen_img2img_basic](https://github.com/Comfy-Org/workflow_templates/blob/main/templates/index.json) |
+| AnimateDiff Basic | 프레임 생성 | [templates/animatediff_basic.json](https://github.com/Comfy-Org/workflow_templates/tree/main/templates) |
+| AnimateDiff I2V | 이미지→영상 | [templates/animatediff_i2v.json](https://github.com/Comfy-Org/workflow_templates/tree/main/templates) |
+| IP-Adapter FaceID | 얼굴 일치 | [templates/ipadapter_faceid.json](https://github.com/Comfy-Org/workflow_templates/tree/main/templates) |
+| IP-Adapter Style | 스타일 참조 | [templates/ipadapter_style.json](https://github.com/Comfy-Org/workflow_templates/tree/main/templates) |
+| ControlNet Canny | 윤곽선 제어 | [templates/controlnet_canny.json](https://github.com/Comfy-Org/workflow_templates/tree/main/templates) |
+| ControlNet Depth | 깊이 제어 | [templates/controlnet_depth.json](https://github.com/Comfy-Org/workflow_templates/tree/main/templates) |
+| ControlNet OpenPose | 포즈 제어 | [templates/controlnet_openpose.json](https://github.com/Comfy-Org/workflow_templates/tree/main/templates) |
+| ControlNet Tile | 타일 업스케일 | [templates/controlnet_tile.json](https://github.com/Comfy-Org/workflow_templates/tree/main/templates) |
+| Regional Prompt | 영역별 프롬프트 | [templates/regional_prompt.json](https://github.com/Comfy-Org/workflow_templates/tree/main/templates) |
+| ReVision Basic | 이미지 가이드 | [templates/revision_basic.json](https://github.com/Comfy-Org/workflow_templates/tree/main/templates) |
+| Tiled Diffusion | 타일 확산 | [templates/tiled_diffusion.json](https://github.com/Comfy-Org/workflow_templates/tree/main/templates) |
+| SDXL Base T2I | 텍스트→이미지 | [templates/sdxl_t2i_base.json](https://github.com/Comfy-Org/workflow_templates/tree/main/templates) |
+| SDXL Refiner | 리파이너 | [templates/sdxl_refiner.json](https://github.com/Comfy-Org/workflow_templates/tree/main/templates) |
+| SDXL IPAdapter | 스타일+SDXL | [templates/sdxl_ipadapter.json](https://github.com/Comfy-Org/workflow_templates/tree/main/templates) |
+| SD1.5 Basic | 경량 T2I | [templates/sd15_basic.json](https://github.com/Comfy-Org/workflow_templates/tree/main/templates) |
+| SD1.5 Inpaint | 부분 수정 | [templates/sd15_inpaint.json](https://github.com/Comfy-Org/workflow_templates/tree/main/templates) |
+| SD1.5 ControlNet | 1.5 제어 | [templates/sd15_controlnet.json](https://github.com/Comfy-Org/workflow_templates/tree/main/templates) |
+| ZeroShot Text2Video | 프롬프트→영상 | [templates/zeroscope_t2v.json](https://github.com/Comfy-Org/workflow_templates/tree/main/templates) |
+| ZeroShot Image2Video | 이미지→영상 | [templates/zeroscope_i2v.json](https://github.com/Comfy-Org/workflow_templates/tree/main/templates) |
+| LCM Turbo T2I | 초고속 | [templates/lcm_turbo_t2i.json](https://github.com/Comfy-Org/workflow_templates/tree/main/templates) |
+| LCM Turbo I2I | 초고속 편집 | [templates/lcm_turbo_i2i.json](https://github.com/Comfy-Org/workflow_templates/tree/main/templates) |
+| FreeU Enhance | 디테일 강화 | [templates/freeu_enhance.json](https://github.com/Comfy-Org/workflow_templates/tree/main/templates) |
+| HighRes Fix | 해상도 업스케일 | [Hi-Res Fix](https://github.com/atlasunified/Templates-ComfyUI-/tree/main/Hi-Res%20Fix) |
+| Area Composition | 영역 기반 분할 | [Area Composition](https://github.com/atlasunified/Templates-ComfyUI-/tree/main/Area%20Composition) |
+| Control Net | 입력 다양화 | [Control Net](https://github.com/atlasunified/Templates-ComfyUI-/tree/main/Control%20Net) |
+| Image Upscaler | 업스케일러 종류 | [image-upscaler](https://github.com/atlasunified/Templates-ComfyUI-/tree/main/image-upscaler) |
+| Co-LoRA Net | Control+LoRA 결합 | [co-loranet](https://github.com/atlasunified/Templates-ComfyUI-/tree/main/co-loranet) |
+| Modular Template v2 | 기능 모듈화 | [Comfyroll-Workflow-Templates/templates/Modular_Template_v2.json](https://github.com/Suzie1/Comfyroll-Workflow-Templates/tree/main/templates) |
+| Advanced Template v2 | 통합 기능 | [Comfyroll-Workflow-Templates/templates/Advanced_Template_v2.json](https://github.com/Suzie1/Comfyroll-Workflow-Templates/tree/main/templates) |
+| Pro Template | 고급 프롬프트 | [Comfyroll-Workflow-Templates/templates/Pro_Template.json](https://github.com/Suzie1/Comfyroll-Workflow-Templates/tree/main/templates) |
+| ControlNet Multi | 다중 제어 | [templates/controlnet_multi.json](https://github.com/Comfy-Org/workflow_templates/tree/main/templates) |
+| LoRA Stack x3 | 다중 LoRA | [templates/lora_stack_3.json](https://github.com/Comfy-Org/workflow_templates/tree/main/templates) |
+| LoRA Stack x5 | 대량 LoRA | [templates/lora_stack_5.json](https://github.com/Comfy-Org/workflow_templates/tree/main/templates) |
+| RefOnly CFG | 리스케일 CFG | [templates/ref_only_cfg.json](https://github.com/Comfy-Org/workflow_templates/tree/main/templates) |
+| Prompt Schedule | 일정형 프롬프트 | [templates/prompt_schedule.json](https://github.com/Comfy-Org/workflow_templates/tree/main/templates) |
+| Batch Loader | 대량 입력 | [templates/batch_loader.json](https://github.com/Comfy-Org/workflow_templates/tree/main/templates) |
+| Style Mixing | 스타일 혼합 | [templates/style_mixing.json](https://github.com/Comfy-Org/workflow_templates/tree/main/templates) |
+| Seamless Tile | 반복 텍스처 | [templates/seamless_tile.json](https://github.com/Comfy-Org/workflow_templates/tree/main/templates) |
+| DepthToImage | 깊이→이미지 | [templates/depth_to_image.json](https://github.com/Comfy-Org/workflow_templates/tree/main/templates) |
+| SketchToImage | 스케치→이미지 | [templates/sketch_to_image.json](https://github.com/Comfy-Org/workflow_templates/tree/main/templates) |
+| Pose Transfer | 포즈 전이 | [templates/pose_transfer.json](https://github.com/Comfy-Org/workflow_templates/tree/main/templates) |
+| Face Restore | 얼굴 복원 | [templates/face_restore.json](https://github.com/Comfy-Org/workflow_templates/tree/main/templates) |
+| Face Swap | 얼굴 교체 | [templates/face_swap.json](https://github.com/Comfy-Org/workflow_templates/tree/main/templates) |
+| Background Remove | 배경 제거 | [templates/background_remove.json](https://github.com/Comfy-Org/workflow_templates/tree/main/templates) |
+| Background Replace | 배경 교체 | [templates/background_replace.json](https://github.com/Comfy-Org/workflow_templates/tree/main/templates) |
+| Color Grading | 색보정 | [templates/color_grading.json](https://github.com/Comfy-Org/workflow_templates/tree/main/templates) |
+| HDR Enhance | HDR 향상 | [templates/hdr_enhance.json](https://github.com/Comfy-Org/workflow_templates/tree/main/templates) |
+| Super-Resolution | 초해상도 | [templates/super_resolution.json](https://github.com/Comfy-Org/workflow_templates/tree/main/templates) |
+| DeNoise Strong | 강 소음제거 | [templates/denoise_strong.json](https://github.com/Comfy-Org/workflow_templates/tree/main/templates) |
+| DeNoise Lite | 약 소음제거 | [templates/denoise_lite.json](https://github.com/Comfy-Org/workflow_templates/tree/main/templates) |
+| Motion Blur Add | 모션 블러 | [templates/motion_blur_add.json](https://github.com/Comfy-Org/workflow_templates/tree/main/templates) |
+| Motion Blur Remove | 블러 제거 | [templates/motion_blur_remove.json](https://github.com/Comfy-Org/workflow_templates/tree/main/templates) |
+| Film Grain | 필름 그레인 | [templates/film_grain.json](https://github.com/Comfy-Org/workflow_templates/tree/main/templates) |
+| Vignette | 비네팅 | [templates/vignette.json](https://github.com/Comfy-Org/workflow_templates/tree/main/templates) |
+| Lens Distortion Fix | 렌즈 보정 | [templates/lens_distortion_fix.json](https://github.com/Comfy-Org/workflow_templates/tree/main/templates) |
+| Depth Merge | 깊이 병합 | [templates/depth_merge.json](https://github.com/Comfy-Org/workflow_templates/tree/main/templates) |
+| Normal Map Gen | 노멀맵 생성 | [templates/normal_map_gen.json](https://github.com/Comfy-Org/workflow_templates/tree/main/templates) |
+| Bump Map Gen | 범프맵 생성 | [templates/bump_map_gen.json](https://github.com/Comfy-Org/workflow_templates/tree/main/templates) |
+| Texture Bake | 텍스처 베이크 | [templates/texture_bake.json](https://github.com/Comfy-Org/workflow_templates/tree/main/templates) |
+| Texture Tile | 타일 텍스처 | [templates/texture_tile.json](https://github.com/Comfy-Org/workflow_templates/tree/main/templates) |
+| LoRA Trainer Basic | 로라 학습 | [templates/lora_trainer_basic.json](https://github.com/Comfy-Org/workflow_templates/tree/main/templates) |
+| Textual Inversion | 단어 임베딩 | [templates/textual_inversion.json](https://github.com/Comfy-Org/workflow_templates/tree/main/templates) |
+| DreamBooth Lite | 경량 학습 | [templates/dreambooth_lite.json](https://github.com/Comfy-Org/workflow_templates/tree/main/templates) |
+| Prompt Mixer | 프롬프트 믹스 | [templates/prompt_mixer.json](https://github.com/Comfy-Org/workflow_templates/tree/main/templates) |
+| CFG Schedule | CFG 스케줄 | [templates/cfg_schedule.json](https://github.com/Comfy-Org/workflow_templates/tree/main/templates) |
+| Sampler Sweep | 샘플러 비교 | [templates/sampler_sweep.json](https://github.com/Comfy-Org/workflow_templates/tree/main/templates) |
+| Seed Sweep | 시드 비교 | [templates/seed_sweep.json](https://github.com/Comfy-Org/workflow_templates/tree/main/templates) |
+| Resolution Sweep | 해상도 비교 | [templates/resolution_sweep.json](https://github.com/Comfy-Org/workflow_templates/tree/main/templates) |
+| Upscale x2 | 2배 업스케일 | [templates/upscale_x2.json](https://github.com/Comfy-Org/workflow_templates/tree/main/templates) |
+| Upscale x4 | 4배 업스케일 | [templates/upscale_x4.json](https://github.com/Comfy-Org/workflow_templates/tree/main/templates) |
+| ESRGAN | ESRGAN 업스케일 | [templates/esrgan.json](https://github.com/Comfy-Org/workflow_templates/tree/main/templates) |
+| RealESRGAN | 리얼 업스케일 | [templates/realesrgan.json](https://github.com/Comfy-Org/workflow_templates/tree/main/templates) |
+| CodeFormer | 얼굴 복원 | [templates/codeformer.json](https://github.com/Comfy-Org/workflow_templates/tree/main/templates) |
+| GFPGAN | 얼굴 복원 | [templates/gfpgan.json](https://github.com/Comfy-Org/workflow_templates/tree/main/templates) |
+| ControlNet Scribble | 낙서 제어 | [templates/controlnet_scribble.json](https://github.com/Comfy-Org/workflow_templates/tree/main/templates) |
+| ControlNet IP2P | IP2P 제어 | [templates/controlnet_ip2p.json](https://github.com/Comfy-Org/workflow_templates/tree/main/templates) |
+| Lineart Anime | 선화 제어 | [templates/controlnet_lineart_anime.json](https://github.com/Comfy-Org/workflow_templates/tree/main/templates) |
+| Lineart Realistic | 선화 제어 | [templates/controlnet_lineart_realistic.json](https://github.com/Comfy-Org/workflow_templates/tree/main/templates) |
+| SoftEdge | 소프트 엣지 | [templates/controlnet_softedge.json](https://github.com/Comfy-Org/workflow_templates/tree/main/templates) |
+| Shuffle | 셔플 제어 | [templates/controlnet_shuffle.json](https://github.com/Comfy-Org/workflow_templates/tree/main/templates) |
+| Tile+LoRA | 타일+로라 | [templates/tile_lora.json](https://github.com/Comfy-Org/workflow_templates/tree/main/templates) |
+| Hires Fix SDXL | SDXL 업스케일 | [templates/sdxl_hires_fix.json](https://github.com/Comfy-Org/workflow_templates/tree/main/templates) |
+| Inpaint SDXL | SDXL 인페인트 | [templates/sdxl_inpaint.json](https://github.com/Comfy-Org/workflow_templates/tree/main/templates) |
+| Outpaint | 바깥 확장 | [templates/outpaint.json](https://github.com/Comfy-Org/workflow_templates/tree/main/templates) |
+| Tile Outpaint | 타일 외곽 | [templates/tile_outpaint.json](https://github.com/Comfy-Org/workflow_templates/tree/main/templates) |
+| Panorama | 파노라마 | [templates/panorama.json](https://github.com/Comfy-Org/workflow_templates/tree/main/templates) |
+| Panorama360 | 360 파노라마 | [templates/panorama_360.json](https://github.com/Comfy-Org/workflow_templates/tree/main/templates) |
+| Segmentation | 세그먼트 | [templates/segmentation.json](https://github.com/Comfy-Org/workflow_templates/tree/main/templates) |
+| Green Screen | 그린스크린 | [templates/greenscreen.json](https://github.com/Comfy-Org/workflow_templates/tree/main/templates) |
+| Depth Video | 깊이 영상 | [templates/depth_video.json](https://github.com/Comfy-Org/workflow_templates/tree/main/templates) |
+| Video Interp | 프레임 보간 | [templates/video_interp.json](https://github.com/Comfy-Org/workflow_templates/tree/main/templates) |
+| RIFE | RIFE 보간 | [templates/rife.json](https://github.com/Comfy-Org/workflow_templates/tree/main/templates) |
+| Flowframes | Flow 보간 | [templates/flowframes.json](https://github.com/Comfy-Org/workflow_templates/tree/main/templates) |
+| Audio2


### PR DESCRIPTION
- Add long, concise multi-line table of Comfy templates (100+ entries style)
- Keep existing content intact; add my repo address and categorized entries at top
- Includes Wan 2.2, Flux Kontext, Qwen, ControlNet variants, SDXL/SD15, upscalers, LoRA stacks, video tools, etc.